### PR TITLE
Change 'val' to 'test' in test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -108,7 +108,7 @@ def test(data,
     if not training:
         # if device.type != 'cpu': #zjq zhushi
         #     model(torch.zeros(1, 3, imgsz, imgsz).to(device).type_as(next(model.parameters())))  # run once
-        task = opt.task if opt.task in ('train', 'val', 'test') else 'val'  # path to train/val/test images
+        task = opt.task if opt.task in ('train', 'val', 'test') else 'test'  # path to train/val/test images
         dataloader = create_dataloader_sr(data[task], imgsz, batch_size, gs, opt, pad=0.5, rect=True,
                             prefix=colorstr(f'{task}: '))[0]
 


### PR DESCRIPTION
It seems like this is leftover code from YOLOV5. I agree with your decision to change the val file to be called test, as it seems to follow machine learning conventions. However, for the sake of consistency, wouldn't it make sense to point to the test file in the YAML rather than the val file . I'm not sure if anyone is reaching the `else` during training, but if you point to 'val' during validation and during evaluation, this could mean that the results are not representative of how the model performs. 

In our fork, we changed the whole line to always point to test, but that probably isn't the best way to do it, lol. This would likely only cause issues if internally the right task is not selected.

This is an awesome concept overall though, I really hope the results weren't skewed by this change. Keep up the good work!