### PR TITLE
Resolve YoloV5 Version Error

### DIFF
--- a/models/SRyolo.py
+++ b/models/SRyolo.py
@@ -272,6 +272,9 @@ class Model(nn.Module):
     def fuse(self):  # fuse model Conv2d() + BatchNorm2d() layers
         print('Fusing layers... ')
         for m in self.model.modules():
+            if isinstance(m, torch.nn.Upsample):
+                m.recompute_scale_factor = None
+            
             if (type(m) is Conv) and hasattr(m, 'bn'):
                 m.conv = fuse_conv_and_bn(m.conv, m.bn)  # update conv
                 delattr(m, 'bn')  # remove batchnorm


### PR DESCRIPTION
It seems like the line here would make a call to an uncaught exception in the current version of YoloV5 (this was fixed in a recent patch). The exception read: AttributeError: 'Upsample' object has no attribute 'recompute_scale_factor'. This solution fixed it, by manually ensuring the blank dict in the stack trace below was not passed.

The stack trace is as follows:

Traceback (most recent call last):
  File "/content/SuperYOLO/test.py", line 139, in test
    out, train_out = model(img,ir,input_mode=input_mode) #zjq inference and training outputs
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/content/SuperYOLO/models/SRyolo.py", line 196, in forward
    y,features = self.forward_once(steam,'yolo', profile) #zjq
  File "/content/SuperYOLO/models/SRyolo.py", line 232, in forward_once
    x = m(x)  # run
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/upsampling.py", line 154, in forward
    recompute_scale_factor=self.recompute_scale_factor)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1185, in __getattr__
    raise AttributeError("'{}' object has no attribute '{}'".format(
AttributeError: 'Upsample' object has no attribute 'recompute_scale_factor'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/content/SuperYOLO/test.py", line 376, in <module>
    test(opt.data,
  File "/content/SuperYOLO/test.py", line 141, in test
    out, train_out,_ = model(img,ir,input_mode=input_mode) #zjq inference and training outputs
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/content/SuperYOLO/models/SRyolo.py", line 196, in forward
    y,features = self.forward_once(steam,'yolo', profile) #zjq
  File "/content/SuperYOLO/models/SRyolo.py", line 232, in forward_once
    x = m(x)  # run
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/upsampling.py", line 154, in forward
    recompute_scale_factor=self.recompute_scale_factor)
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1185, in __getattr__
    raise AttributeError("'{}' object has no attribute '{}'".format(
AttributeError: 'Upsample' object has no attribute 'recompute_scale_factor'